### PR TITLE
fix: public/private subnet configuration for zeebe tasks

### DIFF
--- a/API.md
+++ b/API.md
@@ -263,6 +263,7 @@ const zeebeClusterProps: ZeebeClusterProps = { ... }
 | <code><a href="#zeebe-cdk-constructs.ZeebeClusterProps.property.numBrokerNodes">numBrokerNodes</a></code> | <code>number</code> | The number of Zeebe broker nodes to create in the cluster. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeClusterProps.property.numGatewayNodes">numGatewayNodes</a></code> | <code>number</code> | The number of Zeebe gateway nodes to create in the cluster. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeClusterProps.property.securityGroups">securityGroups</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup[]</code> | The security groups to assign to the cluster. |
+| <code><a href="#zeebe-cdk-constructs.ZeebeClusterProps.property.usePublicSubnets">usePublicSubnets</a></code> | <code>boolean</code> | Create the Zeebe brokers in a public subnet. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeClusterProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | The VPC that the cluster will be created in. |
 
 ---
@@ -423,6 +424,22 @@ The security groups to assign to the cluster.
 
 ---
 
+##### `usePublicSubnets`<sup>Optional</sup> <a name="usePublicSubnets" id="zeebe-cdk-constructs.ZeebeClusterProps.property.usePublicSubnets"></a>
+
+```typescript
+public readonly usePublicSubnets: boolean;
+```
+
+- *Type:* boolean
+
+Create the Zeebe brokers in a public subnet.
+
+If false the Zeebe brokers will be created in a private subnet (with NAT).
+
+Defaults to true.
+
+---
+
 ##### `vpc`<sup>Optional</sup> <a name="vpc" id="zeebe-cdk-constructs.ZeebeClusterProps.property.vpc"></a>
 
 ```typescript
@@ -458,8 +475,8 @@ const zeebeStandaloneProps: ZeebeStandaloneProps = { ... }
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.memory">memory</a></code> | <code>number</code> | The amount of memory to assign to the broker task. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.namespace">namespace</a></code> | <code>aws-cdk-lib.aws_servicediscovery.INamespace</code> | A CloudMap private name space to be used for service discover. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.portMappings">portMappings</a></code> | <code>aws-cdk-lib.aws_ecs.PortMapping[]</code> | Override the port mappings of the container. |
-| <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.public">public</a></code> | <code>boolean</code> | Deploy the zeebe instance into a public subnet so that it can be accessed remotely with an ip address. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.securityGroups">securityGroups</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup[]</code> | The security groups to assign to the cluster. |
+| <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.usePublicSubnets">usePublicSubnets</a></code> | <code>boolean</code> | Deploy the zeebe instance into a public subnet so that it can be accessed remotely with an ip address. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | The VPC that the cluster will be created in. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.zeebeEnvironmentVars">zeebeEnvironmentVars</a></code> | <code>any</code> | Override the environment variables passed to the Zeebe container. |
 
@@ -567,20 +584,6 @@ The default port mappings are 26500, 26501, 26502
 
 ---
 
-##### `public`<sup>Optional</sup> <a name="public" id="zeebe-cdk-constructs.ZeebeStandaloneProps.property.public"></a>
-
-```typescript
-public readonly public: boolean;
-```
-
-- *Type:* boolean
-
-Deploy the zeebe instance into a public subnet so that it can be accessed remotely with an ip address.
-
-The default is false
-
----
-
 ##### `securityGroups`<sup>Optional</sup> <a name="securityGroups" id="zeebe-cdk-constructs.ZeebeStandaloneProps.property.securityGroups"></a>
 
 ```typescript
@@ -590,6 +593,20 @@ public readonly securityGroups: ISecurityGroup[];
 - *Type:* aws-cdk-lib.aws_ec2.ISecurityGroup[]
 
 The security groups to assign to the cluster.
+
+---
+
+##### `usePublicSubnets`<sup>Optional</sup> <a name="usePublicSubnets" id="zeebe-cdk-constructs.ZeebeStandaloneProps.property.usePublicSubnets"></a>
+
+```typescript
+public readonly usePublicSubnets: boolean;
+```
+
+- *Type:* boolean
+
+Deploy the zeebe instance into a public subnet so that it can be accessed remotely with an ip address.
+
+The default is true
 
 ---
 

--- a/src/standalone-props.ts
+++ b/src/standalone-props.ts
@@ -91,7 +91,7 @@ export interface ZeebeStandaloneProps extends GlobalProps {
   /**
      * Deploy the zeebe instance into a public subnet so that it can be accessed remotely with an ip address
      *
-     * The default is false
+     * The default is true
      */
-  readonly public?: boolean;
+  readonly usePublicSubnets?: boolean;
 }

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -29,8 +29,8 @@ export class ZeebeStandaloneFargateCluster extends Construct {
   private props: ZeebeStandaloneProps;
 
   /**
-     * A construct to creates a single standalone Zeebe node that is both gateway and broker deployed on AWS ECS Fargate
-     */
+   * A construct to creates a single standalone Zeebe node that is both gateway and broker deployed on AWS ECS Fargate
+   */
   constructor(scope: Construct, id: string, zeebeProperties: ZeebeStandaloneProps) {
     super(scope, id);
     this.props = this.initProps(zeebeProperties);
@@ -56,7 +56,7 @@ export class ZeebeStandaloneFargateCluster extends Construct {
       securityGroups: securityGroups,
       vpc: defaultVpc,
       fileSystem: undefined,
-      public: false,
+      usePublicSubnets: true,
       portMappings: [
         { containerPort: 26500, hostPort: 26500, protocol: Protocol.TCP },
         { containerPort: 26501, hostPort: 26501, protocol: Protocol.TCP },
@@ -64,13 +64,9 @@ export class ZeebeStandaloneFargateCluster extends Construct {
       ],
       zeebeEnvironmentVars: {
         JAVA_TOOL_OPTIONS: '-Xms512m -Xmx512m ',
-        ZEEBE_STANDALONE_GATEWAY: 'true',
-        ZEEBE_BROKER_GATEWAY_ENABLE: 'true',
         ATOMIX_LOG_LEVEL: 'DEBUG',
         ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK: '0.998',
         ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK: '0.999',
-        ZEEBE_BROKER_EXPORTERS_HAZELCAST_CLASSNAME: 'io.zeebe.hazelcast.exporter.HazelcastExporter',
-        ZEEBE_BROKER_EXPORTERS_HAZELCAST_JARPATH: 'exporters/zeebe-hazelcast-exporter.jar',
         ZEEBE_GATEWAY_NETWORK_HOST: '0.0.0.0',
         ZEEBE_GATEWAY_NETWORK_PORT: '26500',
       },
@@ -103,10 +99,12 @@ export class ZeebeStandaloneFargateCluster extends Construct {
       serviceName: 'zeebe-standalone',
       taskDefinition: this.standaloneTaskDefinition(),
       securityGroups: this.props.securityGroups,
-      vpcSubnets: { subnetType: this.props.public == true ? SubnetType.PUBLIC : SubnetType.PRIVATE_WITH_NAT },
+      assignPublicIp: this.props.usePublicSubnets,
+      vpcSubnets: {
+        subnetType: this.props.usePublicSubnets == true ? SubnetType.PUBLIC : SubnetType.PRIVATE_WITH_NAT,
+      },
       deploymentController: { type: DeploymentControllerType.ECS },
       cloudMapOptions: this.configureCloudMap(),
-      assignPublicIp: false,
     });
 
     return fservice;

--- a/src/zeebe-cluster-props.ts
+++ b/src/zeebe-cluster-props.ts
@@ -7,80 +7,86 @@ import { GlobalProps } from './global-props';
 export interface ZeebeClusterProps extends GlobalProps {
 
   /**
-     * The amount of memory to assign to the broker task
-     *
-     * Must be one of the supported Fargate memory configurations. Defaults to 1024
-     */
+   * The amount of memory to assign to the broker task
+   *
+   * Must be one of the supported Fargate memory configurations. Defaults to 1024
+   */
   readonly memory?: number;
 
   /**
-     * The amount of cpu to assign to the broker task
-     *
-     * Must be one of the supported Fargate memory configurations. Defaults to 512
-     */
+   * The amount of cpu to assign to the broker task
+   *
+   * Must be one of the supported Fargate memory configurations. Defaults to 512
+   */
   readonly cpu?: number;
 
   /**
-     * The security groups to assign to the cluster
-     *
-     */
+   * The security groups to assign to the cluster
+   *
+   */
   readonly securityGroups?: Array<ISecurityGroup>;
 
   /**
-     * The VPC that the cluster will be created in
-     *
-     * If not specified, the cluster will be created in the default VPC
-     */
+   * The VPC that the cluster will be created in
+   *
+   * If not specified, the cluster will be created in the default VPC
+   */
   readonly vpc?: IVpc;
 
   /**
-     * A CloudMap private name space to be used for service discover. If not specified a private name space
-     * called zeebe-cluster.net will be created.
-     *
-     */
+   * A CloudMap private name space to be used for service discover. If not specified a private name space
+   * called zeebe-cluster.net will be created.
+   *
+   */
   readonly namespace?: INamespace;
 
   /**
-     * The ECS cluster to create the Zeebe nodes in. If not specified a new ECS cluster will be created called zeebe-cluster.
-     *
-     */
+   * The ECS cluster to create the Zeebe nodes in. If not specified a new ECS cluster will be created called zeebe-cluster.
+   *
+   */
   readonly ecsCluster?: ICluster;
 
   /**
-     * The number of Zeebe broker nodes to create in the cluster.
-     *
-     * Default value is 3
-     */
+   * The number of Zeebe broker nodes to create in the cluster.
+   *
+   * Default value is 3
+   */
   readonly numBrokerNodes?: number;
 
   /**
-     * The number of Zeebe gateway nodes to create in the cluster.
-     *
-     * Default value is 1
-     */
+   * The number of Zeebe gateway nodes to create in the cluster.
+   *
+   * Default value is 1
+   */
   readonly numGatewayNodes?: number;
 
   /**
-     * An elastic file system to store Zeebe broker data. If not specified the brokers will use ephemeral
-     * Fargate local storage and data will be lost when a node is restarted.
-     *
-     * Default value is 3
-     */
+   * An elastic file system to store Zeebe broker data. If not specified the brokers will use ephemeral
+   * Fargate local storage and data will be lost when a node is restarted.
+   *
+   * Default value is 3
+   */
   readonly fileSystem?: FileSystem;
 
   /**
-     * The amount of memory to assign to the gateway task
-     *
-     * Must be one of the supported Fargate memory configurations. Defaults to 1024
-     */
+   * The amount of memory to assign to the gateway task
+   *
+   * Must be one of the supported Fargate memory configurations. Defaults to 1024
+   */
   readonly gatewayCpu?: number;
 
   /**
-     * The amount of cpu to assign to the gateway task
-     *
-     * Must be one of the supported Fargate memory configurations. Defaults to 1024
-     */
+   * The amount of cpu to assign to the gateway task
+   *
+   * Must be one of the supported Fargate memory configurations. Defaults to 1024
+   */
   readonly gatewayMemory?: number;
 
+  /**
+   * Create the Zeebe brokers in a public subnet. If false the Zeebe brokers will be created in a private subnet (with NAT).
+   *
+   * Defaults to true.
+   */
+  readonly usePublicSubnets?: boolean;
 
 }

--- a/src/zeebe-cluster.ts
+++ b/src/zeebe-cluster.ts
@@ -71,6 +71,7 @@ export class ZeebeFargateCluster extends Construct {
       securityGroups: [securityGroup],
       vpc: defaultVpc,
       fileSystem: defaultFileSystem,
+      usePublicSubnets: true,
     };
 
     return {
@@ -87,7 +88,7 @@ export class ZeebeFargateCluster extends Construct {
       enableAutomaticBackups: false,
       removalPolicy: RemovalPolicy.DESTROY,
       performanceMode: PerformanceMode.GENERAL_PURPOSE,
-      vpcSubnets: { subnetType: SubnetType.PRIVATE_WITH_NAT },
+      vpcSubnets: { subnetType: SubnetType.PUBLIC },
       securityGroup: sg,
     });
 
@@ -119,7 +120,7 @@ export class ZeebeFargateCluster extends Construct {
       vpcSubnets: { subnetType: SubnetType.PUBLIC },
       deploymentController: { type: DeploymentControllerType.ECS },
       cloudMapOptions: this.configureCloudMap(),
-      assignPublicIp: false,
+      assignPublicIp: this.props.usePublicSubnets!,
     });
 
     return fservice;
@@ -136,7 +137,8 @@ export class ZeebeFargateCluster extends Construct {
       serviceName: 'zeebe-broker-' + id,
       taskDefinition: this.brokerTaskDefinition(id),
       securityGroups: this.props.securityGroups,
-      vpcSubnets: { subnetType: SubnetType.PRIVATE_WITH_NAT },
+      vpcSubnets: { subnetType: this.props.usePublicSubnets == true ? SubnetType.PUBLIC : SubnetType.PRIVATE_WITH_NAT },
+      assignPublicIp: this.props.usePublicSubnets!,
       deploymentController: { type: DeploymentControllerType.ECS },
       cloudMapOptions: this.configureCloudMap(),
     });


### PR DESCRIPTION
Use public fargate subnets for deploying zeebe on the default AWS vpc
Set assignPublic to true on default zeebe fargate services

Fixes #