### PR TITLE
feat: support simple monitor co deployment with zeebe standalone

### DIFF
--- a/API.md
+++ b/API.md
@@ -474,11 +474,14 @@ const zeebeStandaloneProps: ZeebeStandaloneProps = { ... }
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.cpu">cpu</a></code> | <code>number</code> | The amount of cpu to assign to the broker task. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.ecsCluster">ecsCluster</a></code> | <code>aws-cdk-lib.aws_ecs.ICluster</code> | The ECS cluster to create the Zeebe nodes in. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.fileSystem">fileSystem</a></code> | <code>aws-cdk-lib.aws_efs.FileSystem</code> | An elastic file system to store Zeebe broker data. |
+| <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.hazelcastExporter">hazelcastExporter</a></code> | <code>boolean</code> | Set to true to enable hazelcast exporter on the Zeebe image. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.memory">memory</a></code> | <code>number</code> | The amount of memory to assign to the broker task. |
-| <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.namespace">namespace</a></code> | <code>aws-cdk-lib.aws_servicediscovery.INamespace</code> | A CloudMap private name space to be used for service discover. |
+| <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.namespace">namespace</a></code> | <code>aws-cdk-lib.aws_servicediscovery.INamespace</code> | If specifying a custom namespace, also set useNamespace to true. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.portMappings">portMappings</a></code> | <code>aws-cdk-lib.aws_ecs.PortMapping[]</code> | Override the port mappings of the container. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.publicGateway">publicGateway</a></code> | <code>boolean</code> | Use this property to control the placement of the Zeebe gateway instance in either a public or private subnet within the VPC. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.securityGroups">securityGroups</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup[]</code> | The security groups to assign to the cluster. |
+| <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.simpleMonitor">simpleMonitor</a></code> | <code>boolean</code> | Set to true to deploy the simple monitor instance along side the Zeebe instance to allow monitoring of processes. |
+| <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.useNamespace">useNamespace</a></code> | <code>boolean</code> | If true, then DNS hostnames will be registered in a Cloud Map to allow for service discovery. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | The VPC that the cluster will be created in. |
 | <code><a href="#zeebe-cdk-constructs.ZeebeStandaloneProps.property.zeebeEnvironmentVars">zeebeEnvironmentVars</a></code> | <code>any</code> | Override the environment variables passed to the Zeebe container. |
 
@@ -541,6 +544,22 @@ Fargate storage will be used and data will be lost when a node is restarted/dest
 
 ---
 
+##### `hazelcastExporter`<sup>Optional</sup> <a name="hazelcastExporter" id="zeebe-cdk-constructs.ZeebeStandaloneProps.property.hazelcastExporter"></a>
+
+```typescript
+public readonly hazelcastExporter: boolean;
+```
+
+- *Type:* boolean
+
+Set to true to enable hazelcast exporter on the Zeebe image.
+
+Note this will build a custom Zeebe image and deploy it onto AWS ECR.
+
+Defaults to false
+
+---
+
 ##### `memory`<sup>Optional</sup> <a name="memory" id="zeebe-cdk-constructs.ZeebeStandaloneProps.property.memory"></a>
 
 ```typescript
@@ -563,10 +582,7 @@ public readonly namespace: INamespace;
 
 - *Type:* aws-cdk-lib.aws_servicediscovery.INamespace
 
-A CloudMap private name space to be used for service discover.
-
-If not specified a private name space
-called zeebe-cluster.net will be created.
+If specifying a custom namespace, also set useNamespace to true.
 
 ---
 
@@ -609,6 +625,36 @@ public readonly securityGroups: ISecurityGroup[];
 - *Type:* aws-cdk-lib.aws_ec2.ISecurityGroup[]
 
 The security groups to assign to the cluster.
+
+---
+
+##### `simpleMonitor`<sup>Optional</sup> <a name="simpleMonitor" id="zeebe-cdk-constructs.ZeebeStandaloneProps.property.simpleMonitor"></a>
+
+```typescript
+public readonly simpleMonitor: boolean;
+```
+
+- *Type:* boolean
+
+Set to true to deploy the simple monitor instance along side the Zeebe instance to allow monitoring of processes.
+
+Defaults to false
+
+---
+
+##### `useNamespace`<sup>Optional</sup> <a name="useNamespace" id="zeebe-cdk-constructs.ZeebeStandaloneProps.property.useNamespace"></a>
+
+```typescript
+public readonly useNamespace: boolean;
+```
+
+- *Type:* boolean
+
+If true, then DNS hostnames will be registered in a Cloud Map to allow for service discovery.
+
+If this value is true and a namespace is not provided then a default private name space called zeebe-cluster.net will be created.
+
+Default is false
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@ This is a library of CDK constructs and patterns for deploying the Camunda Zeebe
 A single Zeebe instance that is configured as both gateway and broker, deployed as Fargate service Deployed in a public
 subnet on AWS default VPC EFS file system is mounted for Zeebe storage /usr/data/local
 
-With the default configuration, the following infrastructure will be created on AWS:
+With the default configuration settings, the following infrastructure will be created on AWS:
 
-* New VPC on CIDR 10.0.0.0/16
-* 1 NAT Gateway
+* Default VPC will be used
 * ECS Cluster - zeebe-standalone
-* 1 Zeebe gateway/broker n a public subnet (Public IP4)
+* 1 Zeebe gateway/broker in a public subnet (Public IP4)
 * Zeebe node is configured as a Fargate task definition and service
 * Ephemeral task storage is mounted at /usr/local/zeebe/data (EFS is an option for persistent storage)
 
@@ -27,10 +26,41 @@ export class ZeebeStandaloneFargateStack extends cdk.Stack {
     constructor(scope: Construct, id: string, props?: cdk.StackProps) {
         super(scope, id, props);
 
-        new ZeebeStandaloneFargateCluster(this, 'ZeebeStandalone', {});
+        new ZeebeStandaloneFargateCluster(this, 'ZeebeStandalone', {
+            // Optional - EFS for persistent storage
+            // fileSystem: new FileSystem(this, 'zeebe-efs', { 
+            //     vpc: Vpc.fromLookup(this, 'my-vpc', {vpcId: 'abcxyz'})
+            // });    
+        });
     }
 }
 
+```
+
+## Deploying Simple Monitor with Zeebe
+
+The Simple monitor application can be deployed alongside the Zeebe instance using the configuration below.
+
+* A custom Zeebe image that includes the Hazelcast exporter will be built and stored in ECR of the AWS account.
+* This configuration will create a larger Fargate task using 2Gb of memory
+
+```typescript
+
+import * as cdk from 'aws-cdk-lib';
+import {Construct} from 'constructs';
+import {ZeebeStandaloneFargateCluster} from "zeebe-cdk-constructs";
+
+export class ZeebeStandaloneFargateStack extends cdk.Stack {
+
+    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        new ZeebeStandaloneFargateCluster(this, 'ZeebeStandaloneWithSimpleMonitor', {
+            simpleMonitor: true,
+            hazelcastExporter: true
+        });
+    }
+}
 
 ```
 

--- a/src/standalone-props.ts
+++ b/src/standalone-props.ts
@@ -35,8 +35,15 @@ export interface ZeebeStandaloneProps extends GlobalProps {
   readonly vpc?: IVpc;
 
   /**
-     * A CloudMap private name space to be used for service discover. If not specified a private name space
-     * called zeebe-cluster.net will be created.
+     * If true, then DNS hostnames will be registered in a Cloud Map to allow for service discovery.
+     * If this value is true and a namespace is not provided then a default private name space called zeebe-cluster.net will be created.
+     *
+     * Default is false
+     */
+  readonly useNamespace?: boolean;
+
+  /**
+     * If specifying a custom namespace, also set useNamespace to true
      *
      */
   readonly namespace?: INamespace;
@@ -87,4 +94,18 @@ export interface ZeebeStandaloneProps extends GlobalProps {
      * Defaults to true.
      */
   readonly publicGateway?: boolean;
+
+  /**
+     * Set to true to deploy the simple monitor instance along side the Zeebe instance to allow monitoring of processes.
+     *
+     * Defaults to false
+     */
+  readonly simpleMonitor?: boolean;
+
+  /**
+     * Set to true to enable hazelcast exporter on the Zeebe image. Note this will build a custom Zeebe image and deploy it onto AWS ECR.
+     *
+     * Defaults to false
+     */
+  readonly hazelcastExporter?: boolean;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,4 +17,5 @@ export class ZeebeCdkUtls {
     return cp;
   }
 
+
 }

--- a/test/standalone.test.ts
+++ b/test/standalone.test.ts
@@ -1,5 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { Peer, Port, SecurityGroup, Vpc } from 'aws-cdk-lib/aws-ec2';
 import { Cluster } from 'aws-cdk-lib/aws-ecs';
 import { FileSystem } from 'aws-cdk-lib/aws-efs';
@@ -47,6 +47,12 @@ describe('ZeebeCluster', () => {
     template.hasResourceProperties('AWS::ECS::Cluster', {
       ClusterName: 'test-cluster',
     });
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: [{ Name: 'zeebe-standalone', Memory: 1024 }],
+    });
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: [Match.not({ Name: 'simple-monitor' })],
+    });
   });
 
 
@@ -83,6 +89,12 @@ describe('ZeebeCluster', () => {
     template.hasResourceProperties('AWS::ECS::Cluster', {
       ClusterName: 'zeebe-standalone',
     });
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: [{ Name: 'zeebe-standalone', Memory: 1024 }],
+    });
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: [Match.not({ Name: 'simple-monitor' })],
+    });
   });
 
   test('Synthesize a standalone zeebe cluster with default settings and private DNS enabled', () => {
@@ -117,6 +129,14 @@ describe('ZeebeCluster', () => {
     template.resourceCountIs('AWS::ServiceDiscovery::PrivateDnsNamespace', 0);
     template.hasResourceProperties('AWS::ECS::Cluster', {
       ClusterName: 'zeebe-standalone',
+    });
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      Cpu: '512',
+      Memory: '1024',
+      ContainerDefinitions: [{ Name: 'zeebe-standalone', Memory: 1024 }],
+    });
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: [Match.not({ Name: 'simple-monitor' })],
     });
   });
 
@@ -156,6 +176,68 @@ describe('ZeebeCluster', () => {
     template.hasResourceProperties('AWS::ECS::Cluster', {
       ClusterName: 'test-cluster',
     });
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      Cpu: '512',
+      Memory: '1024',
+      ContainerDefinitions: [{ Name: 'zeebe-standalone', Memory: 1024 }],
+    });
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: [Match.not({ Name: 'simple-monitor' })],
+    });
+
+  });
+
+  test('Standalone with simple monitor task', () => {
+
+    const app = new cdk.App();
+    const clusterStack = new cdk.Stack(app, 'ZeebeStandaloneStack', {
+      env: {
+        account: process.env.CDK_DEFAULT_ACCOUNT,
+        region: process.env.CDK_DEFAULT_REGION,
+      },
+    });
+
+    const defaultVpc = new Vpc(clusterStack, 'test-vpc', {});
+    const ecsCluster = new Cluster(clusterStack, 'Cluster', { clusterName: 'test-cluster' });
+    const sg = new SecurityGroup(clusterStack, 'test-sg', {
+      vpc: defaultVpc,
+      securityGroupName: 'test-sg',
+      allowAllOutbound: true,
+    });
+    sg.addIngressRule(Peer.anyIpv4(), Port.tcpRange(26500, 26502));
+
+    new ZeebeStandaloneFargateCluster(clusterStack, 'ZeebeStandaloneTestCluster', {
+      vpc: defaultVpc,
+      ecsCluster: ecsCluster,
+      securityGroups: [sg],
+      simpleMonitor: true,
+      hazelcastExporter: true,
+    });
+
+    // Prepare the stack for assertions.
+    let template = Template.fromStack(clusterStack);
+    template.resourceCountIs('AWS::EFS::FileSystem', 0);
+    template.resourceCountIs('AWS::EFS::MountTarget', 0);
+    template.resourceCountIs('AWS::ECS::Service', 1);
+    template.resourceCountIs('AWS::ECS::TaskDefinition', 1);
+    template.resourceCountIs('AWS::ServiceDiscovery::PrivateDnsNamespace', 0);
+    template.hasResourceProperties('AWS::ECS::Cluster', {
+      ClusterName: 'test-cluster',
+    });
+    template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: [
+        {
+          Name: 'zeebe-standalone',
+          Memory: 1024,
+          Image: 'ghcr.io/camunda-community-hub/zeebe-with-hazelcast-exporter:8.0.5',
+        },
+        {
+          Name: 'simple-monitor',
+          Memory: 1024,
+        },
+      ],
+    });
+
   });
 
 


### PR DESCRIPTION
allows configuring simple monitor to be deployed with the standalone
construct

Fixes #24